### PR TITLE
Update org.json:json from 20190722 to 20230227

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
         <version>4.52</version>
-        <relativePath />
+        <relativePath/>
     </parent>
     <groupId>io.jenkins.plugins</groupId>
     <artifactId>codethreat-scanner</artifactId>
@@ -91,7 +91,7 @@
         <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
-            <version>20190722</version>
+            <version>20230227</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
This PR was generated by CodeThreat utilizing authenticated user credentials.

  ## XStream is a Java library to serialize objects to XML and back again. In XStream before version 1.4.16, there is a vulnerability may allow a remote attacker to load and execute arbitrary code from a remote host only by manipulating the processed input stream. No user is affected, who followed the recommendation to setup XStream's security framework with a whitelist limited to the minimal required types. If you rely on XStream's default blacklist of the Security Framework, you will have to use at least version 1.4.16.
  
  ### Changes included in this PR
  
  - Modifications to the following files to address the vulnerabilities with updated dependencies:
    - pom.xml
  
  ### Security Issues Addressed
  
  #### Through Dependency Upgrades:
  
  | Issue | Upgrade | Severity |
  | --- | --- | --- |
  | XStream: allow a remote attacker to load and execute arbitrary code from a remote host only by manipulating the processed input stream | org.json:json: 20190722 -> 20230227 | MEDIUM |
  
  Review the modifications in this PR to confirm they do not introduce any issues to your project.
  